### PR TITLE
Allow directories instead of just file paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,6 +479,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1515,6 +1521,7 @@ dependencies = [
  "atomic-traits",
  "console",
  "flate2",
+ "glob",
  "humantime",
  "indicatif",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ thousands = "0.2"
 humantime = "2.1"
 tokenizers = { version = "0.15.1", features = ["http"] }
 rand = "0.8"
+glob = "0.3.1"
 
 [features]
 default = ["build-binary"]

--- a/src/cmd/botk.rs
+++ b/src/cmd/botk.rs
@@ -15,7 +15,7 @@ use rand::{random, rngs::StdRng, seq::SliceRandom, SeedableRng};
 use serde_json::json;
 use structopt::StructOpt;
 
-use super::util::{parse_size_default_to_gb, DataExecutor, DataInstance};
+use super::util::{expand_dirs, parse_size_default_to_gb, DataExecutor, DataInstance};
 use crate::ngrams::{NgramCounter, TopKNgrams};
 use crate::tokens::{tokenize, PretrainedTokenizer};
 use crate::util;
@@ -101,6 +101,8 @@ pub(crate) struct Opt {
 }
 
 pub(crate) fn main(mut opt: Opt) -> Result<()> {
+    opt.path = expand_dirs(&opt.path)?;
+
     // Validate arguments.
     if opt.path.is_empty() {
         bail!("at least one path is required");

--- a/src/cmd/count.rs
+++ b/src/cmd/count.rs
@@ -11,7 +11,7 @@ use console::style;
 use serde_json::json;
 use structopt::StructOpt;
 
-use super::util::{DataExecutor, DataInstance};
+use super::util::{expand_dirs, DataExecutor, DataInstance};
 use crate::tokens::{tokenize, PretrainedTokenizer};
 use crate::util;
 
@@ -64,6 +64,8 @@ pub(crate) struct Opt {
 }
 
 pub(crate) fn main(mut opt: Opt) -> Result<()> {
+    opt.path = expand_dirs(&opt.path)?;
+
     if opt.search.is_empty() {
         bail!("At least one -s/--search term is required");
     }

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -11,7 +11,7 @@ use serde::Serialize;
 use structopt::StructOpt;
 use thousands::Separable;
 
-use super::util::{DataExecutor, DataInstance};
+use super::util::{expand_dirs, DataExecutor, DataInstance};
 use crate::tokens::{tokenize, PretrainedTokenizer};
 use crate::util;
 
@@ -59,6 +59,8 @@ pub(crate) struct Opt {
 }
 
 pub(crate) fn main(mut opt: Opt) -> Result<()> {
+    opt.path = expand_dirs(&opt.path)?;
+
     if opt.path.is_empty() {
         bail!("at least one path is required");
     }

--- a/src/cmd/topk.rs
+++ b/src/cmd/topk.rs
@@ -15,7 +15,7 @@ use num_traits::{Bounded, NumCast, One, SaturatingSub, Zero};
 use serde_json::json;
 use structopt::StructOpt;
 
-use super::util::{parse_size_default_to_gb, DataExecutor, DataInstance};
+use super::util::{expand_dirs, parse_size_default_to_gb, DataExecutor, DataInstance};
 use crate::ngrams::{NgramCounter, TopKNgrams};
 use crate::tokens::{tokenize, PretrainedTokenizer};
 use crate::util;
@@ -104,6 +104,8 @@ pub(crate) struct Opt {
 }
 
 pub(crate) fn main(mut opt: Opt) -> Result<()> {
+    opt.path = expand_dirs(&opt.path)?;
+
     // Validate arguments.
     if opt.topk == 0 {
         bail!("-k/--topk must be greater than 0");

--- a/src/cmd/unique.rs
+++ b/src/cmd/unique.rs
@@ -7,7 +7,7 @@ use anyhow::{bail, Result};
 use serde_json::json;
 use structopt::StructOpt;
 
-use super::util::{parse_size_default_to_gb, DataExecutor, DataInstance};
+use super::util::{expand_dirs, parse_size_default_to_gb, DataExecutor, DataInstance};
 use crate::ngrams::NgramCounter;
 use crate::tokens::{tokenize, PretrainedTokenizer};
 
@@ -63,6 +63,8 @@ pub(crate) struct Opt {
 }
 
 pub(crate) fn main(mut opt: Opt) -> Result<()> {
+    opt.path = expand_dirs(&opt.path)?;
+
     // Validate arguments.
     if opt.path.is_empty() {
         bail!("at least one path is required");

--- a/src/cmd/util.rs
+++ b/src/cmd/util.rs
@@ -315,7 +315,7 @@ pub(crate) fn parse_size_default_to_gb(src: &str) -> Result<u64, parse_size::Err
     }
 }
 
-pub(crate) fn expand_dirs(paths: &Vec<PathBuf>) -> Result<Vec<PathBuf>> {
+pub(crate) fn expand_dirs(paths: &[PathBuf]) -> Result<Vec<PathBuf>> {
     let mut files = vec![];
     for path in paths {
         if path.is_dir() {

--- a/src/cmd/util.rs
+++ b/src/cmd/util.rs
@@ -112,7 +112,7 @@ pub(crate) struct DataExecutor {
 
 impl DataExecutor {
     pub(crate) fn new(
-        paths: &Vec<PathBuf>,
+        paths: &[PathBuf],
         max_workers: Option<usize>,
         limit: Option<usize>,
         description: &'static str,

--- a/src/cmd/util.rs
+++ b/src/cmd/util.rs
@@ -4,7 +4,8 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use anyhow::{bail, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
+use glob::glob;
 use humantime::format_duration;
 use parse_size::parse_size;
 use serde::Deserialize;
@@ -312,4 +313,22 @@ pub(crate) fn parse_size_default_to_gb(src: &str) -> Result<u64, parse_size::Err
     } else {
         parse_size(format!("{src}GiB"))
     }
+}
+
+pub(crate) fn expand_dirs(paths: &Vec<PathBuf>) -> Result<Vec<PathBuf>> {
+    let mut files = vec![];
+    for path in paths {
+        if path.is_dir() {
+            let path_str = path
+                .to_str()
+                .ok_or_else(|| anyhow!("invalid path '{}'", path.to_string_lossy()))?;
+            for entry in glob(&format!("{}/**/*.json.gz", path_str))? {
+                files.push(entry?.to_path_buf());
+            }
+        } else {
+            files.push(path.clone());
+        }
+    }
+
+    Ok(files)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,9 @@ enum WimbdCmd {
     ///
     /// > wimbd topk c4-train.01011-of-01024.json.gz --ngram=3 --topk=20 --seed=42 --size=50GiB
     ///
+    /// You can also pass directories instead of files, in which case files will be found by
+    /// globbing for '**/*.json.gz' within each directory.
+    ///
     /// ACCURACY
     ///
     /// In general you should set '--size' to however many free gigabytes of RAM you have available, minus some buffer room.


### PR DESCRIPTION
Allow passing directories to `wimbd` commands instead of just file paths. Directories will be expanded to paths using the glob `**/*.json.gz`. 