### PR TITLE
Add `--with-locations` flag to `wimbd search`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1520,7 +1520,7 @@ checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
 
 [[package]]
 name = "wimbd"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "ahash",
  "anyhow",

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -65,6 +65,8 @@ pub(crate) struct Opt {
     force: bool,
 }
 
+type MatchLocationsPerPath = HashMap<PathBuf, Vec<MatchLocation>, RandomState>;
+
 pub(crate) fn main(mut opt: Opt) -> Result<()> {
     opt.path = expand_dirs(&opt.path)?;
 
@@ -85,9 +87,7 @@ pub(crate) fn main(mut opt: Opt) -> Result<()> {
         HashMap::with_capacity_and_hasher(opt.pattern.len(), RandomState::new());
     let mut patterns: HashMap<String, Regex, RandomState> =
         HashMap::with_capacity_and_hasher(opt.pattern.len(), RandomState::new());
-    let mut match_locations: Option<
-        HashMap<String, HashMap<PathBuf, Vec<MatchLocation>, RandomState>, RandomState>,
-    > = None;
+    let mut match_locations: Option<HashMap<String, MatchLocationsPerPath, RandomState>> = None;
     let mut tx: Option<SyncSender<(String, PathBuf, Vec<MatchLocation>)>> = None;
     let mut rx: Option<Receiver<(String, PathBuf, Vec<MatchLocation>)>> = None;
     if opt.with_locations {


### PR DESCRIPTION
For including the location of each match in the output.
Closes #13.

For example:

```fish
cargo run -- search test_fixtures/c4-sample.00000-of-00001.json.gz -p '\bCascara' --with-locations --json
```

will output:

```json
{"count":5,"matches":{"test_fixtures/c4-sample.00000-of-00001.json.gz":[{"line_num":24,"submatches":[{"end_col":7,"start_col":0},{"end_col":16,"start_col":9},{"end_col":279,"start_col":272},{"end_col":330,"start_col":323},{"end_col":339,"start_col":332}],"text":"Cascara (Cascara sagrada) by Eagle Peak Herbals: This North American shrub is a well known laxative and colon cleanser that has been widely used by physicians as well as native peoples. Many commercial preparations intended to treat constipation contain the cured bark of Cascara sagrada. Famous for \"next morning results.\nCascara (Cascara sagrada), certified organic grain alcohol, and distilled water."}]},"pattern":"\\bCascara"}
```